### PR TITLE
Add Express 4 login example

### DIFF
--- a/examples/login_express_4/app.js
+++ b/examples/login_express_4/app.js
@@ -1,0 +1,122 @@
+var express = require('express')
+  , passport = require('passport')
+  , util = require('util')
+  , StravaStrategy = require('passport-strava-oauth2').Strategy;
+
+var STRAVA_CLIENT_ID = process.env.STRAVA_CLIENT_ID;
+var STRAVA_CLIENT_SECRET = process.env.STRAVA_CLIENT_SECRET;
+
+
+// Passport session setup.
+//   To support persistent login sessions, Passport needs to be able to
+//   serialize users into and deserialize users out of the session.  Typically,
+//   this will be as simple as storing the user ID when serializing, and finding
+//   the user by ID when deserializing.  However, since this example does not
+//   have a database of user records, the complete Strava profile is
+//   serialized and deserialized.
+passport.serializeUser(function(user, done) {
+  done(null, user);
+});
+
+passport.deserializeUser(function(obj, done) {
+  done(null, obj);
+});
+
+
+// Use the StravaStrategy within Passport.
+//   Strategies in Passport require a `verify` function, which accept
+//   credentials (in this case, an accessToken, refreshToken, and Strava
+//   profile), and invoke a callback with a user object.
+passport.use(new StravaStrategy({
+    clientID: STRAVA_CLIENT_ID,
+    clientSecret: STRAVA_CLIENT_SECRET,
+    callbackURL: "http://127.0.0.1:3000/auth/strava/callback"
+  },
+  function(accessToken, refreshToken, profile, done) {
+    // asynchronous verification, for effect...
+    process.nextTick(function () {
+      
+      // To keep the example simple, the user's Strava profile is returned to
+      // represent the logged-in user.  In a typical application, you would want
+      // to associate the Strava account with a user record in your database,
+      // and return that user instead.
+      return done(null, profile);
+    });
+  }
+));
+
+
+
+
+var app = express.createServer();
+
+// configure Express
+app.configure(function() {
+  app.set('views', __dirname + '/views');
+  app.set('view engine', 'ejs');
+  app.use(express.logger());
+  app.use(express.cookieParser());
+  app.use(express.bodyParser());
+  app.use(express.methodOverride());
+  app.use(express.session({ secret: 'keyboard cat' }));
+  // Initialize Passport!  Also use passport.session() middleware, to support
+  // persistent login sessions (recommended).
+  app.use(passport.initialize());
+  app.use(passport.session());
+  app.use(app.router);
+  app.use(express.static(__dirname + '/public'));
+});
+
+
+app.get('/', function(req, res){
+  res.render('index', { user: req.user });
+});
+
+app.get('/account', ensureAuthenticated, function(req, res){
+  res.render('account', { user: req.user });
+});
+
+app.get('/login', function(req, res){
+  res.render('login', { user: req.user });
+});
+
+// GET /auth/strava
+//   Use passport.authenticate() as route middleware to authenticate the
+//   request.  The first step in Strava authentication will involve
+//   redirecting the user to strava.com.  After authorization, Strava
+//   will redirect the user back to this application at /auth/strava/callback
+app.get('/auth/strava',
+  passport.authenticate('strava', { scope: ['public'] }),
+  function(req, res){
+    // The request will be redirected to Strava for authentication, so this
+    // function will not be called.
+  });
+
+// GET /auth/strava/callback
+//   Use passport.authenticate() as route middleware to authenticate the
+//   request.  If authentication fails, the user will be redirected back to the
+//   login page.  Otherwise, the primary route function function will be called,
+//   which, in this example, will redirect the user to the home page.
+app.get('/auth/strava/callback', 
+  passport.authenticate('strava', { failureRedirect: '/login' }),
+  function(req, res) {
+    res.redirect('/');
+  });
+
+app.get('/logout', function(req, res){
+  req.logout();
+  res.redirect('/');
+});
+
+app.listen(3000);
+
+
+// Simple route middleware to ensure user is authenticated.
+//   Use this route middleware on any resource that needs to be protected.  If
+//   the request is authenticated (typically via a persistent login session),
+//   the request will proceed.  Otherwise, the user will be redirected to the
+//   login page.
+function ensureAuthenticated(req, res, next) {
+  if (req.isAuthenticated()) { return next(); }
+  res.redirect('/login')
+}

--- a/examples/login_express_4/app.js
+++ b/examples/login_express_4/app.js
@@ -1,4 +1,9 @@
 var express = require('express')
+  , logger = require('morgan')
+  , cookieParser = require('cookie-parser')
+  , bodyParser = require('body-parser')
+  , session = require('express-session')
+  , methodOverride = require('method-override')
   , passport = require('passport')
   , util = require('util')
   , StravaStrategy = require('passport-strava-oauth2').Strategy;
@@ -48,24 +53,22 @@ passport.use(new StravaStrategy({
 
 
 
-var app = express.createServer();
+var app = express();
 
 // configure Express
-app.configure(function() {
-  app.set('views', __dirname + '/views');
-  app.set('view engine', 'ejs');
-  app.use(express.logger());
-  app.use(express.cookieParser());
-  app.use(express.bodyParser());
-  app.use(express.methodOverride());
-  app.use(express.session({ secret: 'keyboard cat' }));
-  // Initialize Passport!  Also use passport.session() middleware, to support
-  // persistent login sessions (recommended).
-  app.use(passport.initialize());
-  app.use(passport.session());
-  app.use(app.router);
-  app.use(express.static(__dirname + '/public'));
-});
+app.set('views', __dirname + '/views');
+app.set('view engine', 'ejs');
+app.use(logger('dev'));
+app.use(cookieParser());
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended : true}));
+app.use(methodOverride());
+app.use(session({ secret: 'keyboard cat' }));
+// Initialize Passport!  Also use passport.session() middleware, to support
+// persistent login sessions (recommended).
+app.use(passport.initialize());
+app.use(passport.session());
+app.use(express.static(__dirname + '/public'));
 
 
 app.get('/', function(req, res){

--- a/examples/login_express_4/package.json
+++ b/examples/login_express_4/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "passport-strava-examples-login",
+  "version": "0.0.0",
+  "dependencies": {
+    "express": "2.x.x",
+    "ejs": ">= 0.0.0",
+    "passport": ">= 0.0.0",
+    "passport-strava-oauth2": ">= 0.1.1"
+  }
+}

--- a/examples/login_express_4/package.json
+++ b/examples/login_express_4/package.json
@@ -2,9 +2,15 @@
   "name": "passport-strava-examples-login",
   "version": "0.0.0",
   "dependencies": {
-    "express": "2.x.x",
-    "ejs": ">= 0.0.0",
-    "passport": ">= 0.0.0",
-    "passport-strava-oauth2": ">= 0.1.1"
+    "body-parser": "^1.17.2",
+    "cookie-parser": "^1.4.3",
+    "ejs": "^2.5.7",
+    "express": "^4.15.3",
+    "express-session": "^1.15.4",
+    "method-override": "^2.3.9",
+    "morgan": "^1.8.2",
+    "passport": "^0.3.2",
+    "passport-strava-oauth2": "^0.1.3",
+    "util": "^0.10.3"
   }
 }

--- a/examples/login_express_4/views/account.ejs
+++ b/examples/login_express_4/views/account.ejs
@@ -1,0 +1,4 @@
+<p><img src="<%= user.photos[0].value %>"></p>
+<p>ID: <%= user.id %></p>
+<p>Name: <%= user.displayName %></p>
+<p>City: <%= user._json.city %></p>

--- a/examples/login_express_4/views/index.ejs
+++ b/examples/login_express_4/views/index.ejs
@@ -1,0 +1,5 @@
+<% if (!user) { %>
+	<h2>Welcome! Please log in.</h2>
+<% } else { %>
+	<h2>Hello, <%= user.displayName %>.</h2>
+<% } %>

--- a/examples/login_express_4/views/layout.ejs
+++ b/examples/login_express_4/views/layout.ejs
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Passport-Strava Example</title>
+	</head>
+	<body>
+		<% if (!user) { %>
+			<p>
+			<a href="/">Home</a> | 
+			<a href="/login">Log In</a>
+			</p>
+		<% } else { %>
+			<p>
+			<a href="/">Home</a> | 
+			<a href="/account">Account</a> | 
+			<a href="/logout">Log Out</a>
+			</p>
+		<% } %>
+		<%- body %>
+	</body>
+</html>

--- a/examples/login_express_4/views/login.ejs
+++ b/examples/login_express_4/views/login.ejs
@@ -1,0 +1,1 @@
+<a href="/auth/strava">Login with Strava</a>


### PR DESCRIPTION
I added a folder in the _examples_ folder with the original example redone using Express 4. The changes were made according to the recommendations found on [the official guide](https://expressjs.com/en/guide/migrating-4.html). 
My additions are:

- Created a copy of the Express 2 example folder;

- Changed the _app.js_ file to reflect the removal of the _app.config_ function and added the necessary packages that are no longer part of Express core;

- Updated the package.json file to add the packages added above and Express 4.